### PR TITLE
Added delays to Routines file in ROUTINE_SETTINGS dict

### DIFF
--- a/CMSPIX28Spacely_Config.py
+++ b/CMSPIX28Spacely_Config.py
@@ -1,7 +1,7 @@
 
 
 INSTR = {"car" : {"type": "Caribou",
-                  "host":"192.168.1.24",
+                  "host":"mud.uchicago.edu",
                   "port":12345,
                   "device":"SpacelyCaribouBasic"}}
 
@@ -76,9 +76,9 @@ V_LEVEL = {"vdda": 0.9,
            "vth1": 0.031, #0.08 is 1500e-
            "vth2": 0.031, #0.11 is 2000e-
            "VMC": 0.4,
-           "SUPERPIX":0,
+           "SUPERPIX":0.9,#0,
+           "Ibias": 0.6,            #TUNE TO have 5uW/pixel
            "INJ_1": 2,
-           "Ibias": 0.6            #TUNE TO have 5uW/pixel
 }
 
 I_LEVEL = {
@@ -135,7 +135,29 @@ I_VOLT_LIMIT = {
 
 
 FNAL_SETTINGS = {
-    "storageDirectory" : "/mnt/local/CMSPIX28/data",#"/mnt/local/CMSPIX28/data/ChipVersion1_ChipID17_SuperPix1/Pnoise",#"/mnt/local/CMSPIX28/Scurve/data",#
+    "storageDirectory" : "/local/d1/smartpixLab/scurveData", # "/mnt/local/CMSPIX28/data",#"/mnt/local/CMSPIX28/data/ChipVersion1_ChipID17_SuperPix1/Pnoise",#"/mnt/local/CMSPIX28/Scurve/data",#
     "chipVersion" : 1,
-    "chipID" : 17
+    "chipID" : 16,
+    "pixel_compout_csv" : "/local/d1/smartpixLab/filter/model_pipeline/tmp/923_1847_3695/compouts_ylocal_0.00_1.35.csv",
+    "dnn_csv" : "/local/d1/smartpixLab/filter/model_pipeline/tmp/firmware/weights/b5_w5_b2_w2_pixel_bin.csv",
+        
+}
+
+ROUTINE_SETTINGS = {
+    "configclk_period" : '64',
+    "cfg_test_delay" : '5',
+    "cfg_test_sample" :'20',
+    "cfg_test_gate_config_clk" :'1',
+    "scan_load_delay" : '19',#'13', #in some parts of the code, this is #superpix1 '1C', superpix2 '1E',
+    "startBxclkState" : '0',
+    "bxclk_delay" : '12',   #in some parts of the code, this is '11' for superpix 1 and '12' for superpixel 2
+    "bxclk_period" : '28',
+    "injection_delay" : 'c',# '1E', #original was '1E' in ~r3 and ~r6 and ~r7, but for some reason '1D' in ~r4 #in some parts of the code, #superpix1 '1C', superpix2 '1E',
+    "scanLoopBackBit" : '0',
+    "test_sample" : 'F',
+    "test_delay" : '14',
+    "scanLoadPhase" : '26', #in some parts of the code, this is  #superpix1 '25', superpix2 '26',
+    "loopbackBit" : 0,
+    "progResetMask" : '0', #seems only for DNN function and ROUTINE_DNN
+    "configClkGate" : '0', #seems only for DNN function and ROUTINE_DNN
 }

--- a/CMSPIX28Spacely_Config.py
+++ b/CMSPIX28Spacely_Config.py
@@ -15,7 +15,9 @@ V_SEQUENCE = ["vdda",
               "VMC", 
               "SUPERPIX", 
               "INJ_1",
-              "Ibias"
+              "Ibias",
+              "disc0",
+              "disc1",
 ]
 
 I_SEQUENCE = [
@@ -36,7 +38,9 @@ V_INSTR = {"vdda": "car",
            "VMC":"car",
            "SUPERPIX":"car",
            "INJ_1": "car",
-           "Ibias": "car"
+           "Ibias": "car",
+           "disc0": "car",
+           "disc1": "car",
 }
 
 I_INSTR = {
@@ -57,7 +61,9 @@ V_CHAN = {"vdda": "PWR_OUT_1",
            "VMC":"BIAS_1",
            "SUPERPIX":"BIAS_5",
            "INJ_1":"INJ_1",
-           "Ibias":"BIAS_26"
+           "Ibias":"BIAS_26",
+           "disc0":"BIAS_7",
+           "disc1":"BIAS_9",
 }
 
 I_CHAN = {
@@ -72,13 +78,15 @@ I_CHAN = {
 
 V_LEVEL = {"vdda": 0.9,
            "vddd": 0.9,
-           "vth0": 0.031, #0.05 is 1000e-
-           "vth1": 0.031, #0.08 is 1500e-
-           "vth2": 0.031, #0.11 is 2000e-
+           "vth0": 0.05,#0.031, #0.05 is 1000e-
+           "vth1": 0.08,#0.031, #0.08 is 1500e-
+           "vth2": 0.11,#0.031, #0.11 is 2000e-
            "VMC": 0.4,
-           "SUPERPIX":0.9,#0,
+           "SUPERPIX":0,#0.9,#0,
            "Ibias": 0.6,            #TUNE TO have 5uW/pixel
            "INJ_1": 2,
+           "disc0":0,
+           "disc1":0,
 }
 
 I_LEVEL = {
@@ -99,7 +107,9 @@ V_WARN_VOLTAGE = {"vdda": [0.82,0.99],
            "VMC": [0,0.4],
            "SUPERPIX":[0,0.99],
            "INJ_1": [1.8,2.2],
-           "Ibias": [0,0.9]
+           "Ibias": [0,0.9],
+           "disc0": [0,2],
+           "disc1": [0,2],
       }
 
 V_PORT  = {"vdda": None,
@@ -110,7 +120,9 @@ V_PORT  = {"vdda": None,
            "VMC":None,
            "SUPERPIX":None,
            "INJ_1": None,
-           "Ibias": None
+           "Ibias": None,
+           "disc0": None,
+           "disc1": None,
 }
 
 I_PORT = {
@@ -137,13 +149,34 @@ I_VOLT_LIMIT = {
 FNAL_SETTINGS = {
     "storageDirectory" : "/local/d1/smartpixLab/scurveData", # "/mnt/local/CMSPIX28/data",#"/mnt/local/CMSPIX28/data/ChipVersion1_ChipID17_SuperPix1/Pnoise",#"/mnt/local/CMSPIX28/Scurve/data",#
     "chipVersion" : 1,
-    "chipID" : 16,
+    "chipID" : 22,#16,
     "pixel_compout_csv" : "/local/d1/smartpixLab/filter/model_pipeline/tmp/923_1847_3695/compouts_ylocal_0.00_1.35.csv",
     "dnn_csv" : "/local/d1/smartpixLab/filter/model_pipeline/tmp/firmware/weights/b5_w5_b2_w2_pixel_bin.csv",
         
 }
 
-ROUTINE_SETTINGS = {
+ROUTINE_SETTINGS_UC = {
+    "configclk_period" : '64',
+    "cfg_test_delay" : '5',
+    "cfg_test_sample" :'20',
+    "cfg_test_gate_config_clk" :'1',
+    "scan_load_delay" : '19',#'13', #in some parts of the code, this is #superpix1 '1C', superpix2 '1E',
+    "startBxclkState" : '0',
+    "bxclk_delay" : '12',   #in some parts of the code, this is '11' for superpix 1 and '12' for superpixel 2
+    "bxclk_period" : '28',
+    "injection_delay" : 'c',# '1E', #original was '1E' in ~r3 and ~r6 and ~r7, but for some reason '1D' in ~r4 #in some parts of the code, #superpix1 '1C', superpix2 '1E',
+    "scanLoopBackBit" : '0',
+    "test_sample" : 'F',
+    "test_delay" : '14',
+    "scanLoadPhase" : '26', #in some parts of the code, this is  #superpix1 '25', superpix2 '26',
+    "loopbackBit" : 0,
+    "progResetMask" : '0', #seems only for DNN function and ROUTINE_DNN
+    "configClkGate" : '0', #seems only for DNN function and ROUTINE_DNN
+
+}
+
+#TODO: Update for FNAL
+ROUTINE_SETTINGS_FNAL = {
     "configclk_period" : '64',
     "cfg_test_delay" : '5',
     "cfg_test_sample" :'20',
@@ -161,3 +194,27 @@ ROUTINE_SETTINGS = {
     "progResetMask" : '0', #seems only for DNN function and ROUTINE_DNN
     "configClkGate" : '0', #seems only for DNN function and ROUTINE_DNN
 }
+
+#TODO: Update for Cornell
+ROUTINE_SETTINGS_CORNELL = {
+    "configclk_period" : '64',
+    "cfg_test_delay" : '5',
+    "cfg_test_sample" :'20',
+    "cfg_test_gate_config_clk" :'1',
+    "scan_load_delay" : '19',#'13', #in some parts of the code, this is #superpix1 '1C', superpix2 '1E',
+    "startBxclkState" : '0',
+    "bxclk_delay" : '12',   #in some parts of the code, this is '11' for superpix 1 and '12' for superpixel 2
+    "bxclk_period" : '28',
+    "injection_delay" : 'c',# '1E', #original was '1E' in ~r3 and ~r6 and ~r7, but for some reason '1D' in ~r4 #in some parts of the code, #superpix1 '1C', superpix2 '1E',
+    "scanLoopBackBit" : '0',
+    "test_sample" : 'F',
+    "test_delay" : '14',
+    "scanLoadPhase" : '26', #in some parts of the code, this is  #superpix1 '25', superpix2 '26',
+    "loopbackBit" : 0,
+    "progResetMask" : '0', #seems only for DNN function and ROUTINE_DNN
+    "configClkGate" : '0', #seems only for DNN function and ROUTINE_DNN
+}
+
+
+#Set it to FNAL or Cornell when using those test stands
+ROUTINE_SETTINGS=ROUTINE_SETTINGS_UC

--- a/CMSPIX28Spacely_Routines.py
+++ b/CMSPIX28Spacely_Routines.py
@@ -60,23 +60,43 @@ def onstartup():
 
 
 #<<Registered w/ Spacely as ROUTINE 0, call as ~r0>>
-def ROUTINE_ProgShiftRegRaw(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1'):
+def ROUTINE_ProgShiftRegRaw(
+        configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"]):
     return ProgShiftRegRaw(configclk_period, cfg_test_delay, cfg_test_sample,cfg_test_gate_config_clk)
 
 #<<Registered w/ Spacely as ROUTINE 1, call as ~r1>>
-def ROUTINE_ProgPixelsOnly( configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1',pixelList = [0], pixelValue=[1]):
+def ROUTINE_ProgPixelsOnly(
+        configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"],
+        pixelList = [0], pixelValue=[1]):
     return ProgPixelsOnly(configclk_period, cfg_test_delay, cfg_test_sample,cfg_test_gate_config_clk,pixelList, pixelValue) 
 
 #<<Registered w/ Spacely as ROUTINE 2, call as ~r2>>
-def ROUTINE_ProgShiftRegs(progDebug=False, verbose=False, configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1', iP=0, timeSleep=0.011):
+def ROUTINE_ProgShiftRegs(
+        progDebug=False, verbose=False, 
+        configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+        iP=0, timeSleep=0.011):
     return ProgShiftRegs(progDebug, verbose, configclk_period, cfg_test_delay, cfg_test_sample,cfg_test_gate_config_clk, iP, timeSleep)
 
 #<<Registered w/ Spacely as ROUTINE 3, call as ~r3>>
-def ROUTINE_ScanChainOneShot(scan_load_delay='13', startBxclkState='0', bxclk_delay='12', bxclk_period='28', injection_delay='1E', scanLoopBackBit='0', test_sample='F', test_delay='14', scanLoadPhase ='26'):
+def ROUTINE_ScanChainOneShot(
+        scan_load_delay=ROUTINE_SETTINGS["scan_load_delay"], startBxclkState=ROUTINE_SETTINGS["startBxclkState"], 
+        bxclk_delay=ROUTINE_SETTINGS["bxclk_delay"], bxclk_period=ROUTINE_SETTINGS["bxclk_period"],
+        injection_delay=ROUTINE_SETTINGS["injection_delay"], scanLoopBackBit=ROUTINE_SETTINGS["scanLoopBackBit"], 
+        test_sample=ROUTINE_SETTINGS["test_sample"], test_delay=ROUTINE_SETTINGS["test_delay"], 
+        scanLoadPhase =ROUTINE_SETTINGS["scanLoadPhase"]):
     return ScanChainOneShot(scan_load_delay, startBxclkState, bxclk_delay, bxclk_period, injection_delay, scanLoopBackBit, test_sample, test_delay, scanLoadPhase )
 
 #<<Registered w/ Spacely as ROUTINE 4, call as ~r4>>
-def ROUTINE_PreProgSCurve(scanLoadPhase = '26', scan_load_delay='13', startBxclkState='0', bxclk_delay='12', bxclk_period='28', injection_delay='1D', scanLoopBackBit='0', test_sample='0F', test_delay='14', v_min = 0.001, v_max=0.4, v_step=0.001, nsample=1000, nPix=0):
+def ROUTINE_PreProgSCurve(
+        scanLoadPhase =ROUTINE_SETTINGS["scanLoadPhase"], 
+        scan_load_delay=ROUTINE_SETTINGS["scan_load_delay"], startBxclkState=ROUTINE_SETTINGS["startBxclkState"], 
+        bxclk_delay=ROUTINE_SETTINGS["bxclk_delay"], bxclk_period=ROUTINE_SETTINGS["bxclk_period"],
+        injection_delay=ROUTINE_SETTINGS["injection_delay"], scanLoopBackBit=ROUTINE_SETTINGS["scanLoopBackBit"], 
+        test_sample=ROUTINE_SETTINGS["test_sample"], test_delay=ROUTINE_SETTINGS["test_delay"], 
+        v_min = 0.001, v_max=0.4, v_step=0.001, nsample=1000, nPix=0):
     return PreProgSCurve(scanLoadPhase, scan_load_delay, startBxclkState, bxclk_delay, bxclk_period, injection_delay, scanLoopBackBit, test_sample, test_delay, v_min, v_max, v_step, nsample, nPix)
 
 #<<Registered w/ Spacely as ROUTINE 5, call as ~r5>>
@@ -85,16 +105,28 @@ def ROUTINE_SCurveMatrix():
 
 #<<Registered w/ Spacely as ROUTINE 6, call as ~r6>>
 def ROUTINE_DNN(
-        progDebug=False, loopbackBit=0, patternIndexes = [0], verbose=False, 
-        injection_delay='1E', bxclk_period='28', startBxclkState='0',scan_load_delay='13', 
-        cfg_test_delay='5', cfg_test_sample='20', progResetMask='0', configclk_period='64', 
-        test_delay='14', test_sample='0F', bxclk_delay='12',configClkGate='0',scanLoadPhase ='26',
-        vth0 = 0.08, vth1=0.16, vth2=0.32, readYproj=True, pixel_compout_csv=None, dnn_csv=None
+        progDebug=False, loopbackBit=ROUTINE_SETTINGS["loopbackBit"], patternIndexes = [0], verbose=False, 
+        injection_delay=ROUTINE_SETTINGS["injection_delay"], bxclk_period=ROUTINE_SETTINGS["bxclk_period"],
+        startBxclkState=ROUTINE_SETTINGS["startBxclkState"],scan_load_delay=ROUTINE_SETTINGS["scan_load_delay"], 
+        cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"], 
+        progResetMask=ROUTINE_SETTINGS["progResetMask"], configclk_period=ROUTINE_SETTINGS["configclk_period"], 
+        test_delay=ROUTINE_SETTINGS["test_delay"], test_sample=ROUTINE_SETTINGS["test_sample"], 
+        bxclk_delay=ROUTINE_SETTINGS["bxclk_delay"],configClkGate=ROUTINE_SETTINGS["configClkGate"],
+        scanLoadPhase =ROUTINE_SETTINGS["scanLoadPhase"],
+        vth0 = 0.08, vth1=0.16, vth2=0.32, readYproj=True, 
+        pixel_compout_csv=FNAL_SETTINGS["pixel_compout_csv"], dnn_csv=FNAL_SETTINGS["dnn_csv"]
 ):
+        
         return DNN(progDebug,loopbackBit, patternIndexes, verbose, injection_delay, bxclk_period, startBxclkState, scan_load_delay, cfg_test_delay, cfg_test_sample, progResetMask, configclk_period, test_delay, test_sample, bxclk_delay,configClkGate, scanLoadPhase, vth0=vth0, vth1=vth1, vth2=vth2, readYproj=readYproj, pixel_compout_csv=pixel_compout_csv, dnn_csv=dnn_csv)
 
 #<<Registered w/ Spacely as ROUTINE 7, call as ~r7>>
-def ROUTINE_DiscrimTuneScanChain(nEvents=1000, time_sleep = 1, dnn_Pattern=0,  scan_load_delay='13', startBxclkState='0', bxclk_delay='12', bxclk_period='28', injection_delay='1E', scanLoopBackBit='0', test_sample='F', test_delay='14', scanLoadPhase ='26'):
+def ROUTINE_DiscrimTuneScanChain(
+        nEvents=1000, time_sleep = 1, dnn_Pattern=0,  
+        scan_load_delay=ROUTINE_SETTINGS["scan_load_delay"], startBxclkState=ROUTINE_SETTINGS["startBxclkState"], 
+        bxclk_delay=ROUTINE_SETTINGS["bxclk_delay"], bxclk_period=ROUTINE_SETTINGS["bxclk_period"],
+        injection_delay=ROUTINE_SETTINGS["injection_delay"], scanLoopBackBit=ROUTINE_SETTINGS["scanLoopBackBit"], 
+        test_sample=ROUTINE_SETTINGS["test_sample"], test_delay=ROUTINE_SETTINGS["test_delay"], 
+        scanLoadPhase =ROUTINE_SETTINGS["scanLoadPhase"]):
     ROUTINE_DNN(patternIndexes=[dnn_Pattern])
     print("Routine_DNN completed, starting ScanChainOneShot loop.")
     for evt_iter in range(nEvents):
@@ -102,14 +134,20 @@ def ROUTINE_DiscrimTuneScanChain(nEvents=1000, time_sleep = 1, dnn_Pattern=0,  s
         print(f'ScanChainOneShot number {evt_iter+1} executed, sleeping 1s.')
         time.sleep(1)
 
-
+#
 #<<Registered w/ Spacely as ROUTINE 8, call as ~r8>>
 def ROUTINE_SettingsScan(
-        loopbackBit=0, patternIndexes = [2], verbose=False, vin_test='1D', 
-        freq='3f', start_bxclk_state='0', cfg_test_delay='08', cfg_test_sample='08', 
-        bxclk_delay='0B', scanload_delay='13'
+        loopbackBit=ROUTINE_SETTINGS["loopbackBit"], patternIndexes = [2], verbose=False, vin_test='1D', freq='3f', 
+        start_bxclk_state=ROUTINE_SETTINGS["startBxclkState"],
+        # cfg_test_delay='08', #original setting is '08' instead of the '05' used in other routines
+        cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        # cfg_test_sample='08', #original setting is '08' instead of the '20' used in other routines
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"], 
+        # bxclk_delay='0B', #original setting is '0B' instead of the the '12' used in other routines
+        bxclk_delay=ROUTINE_SETTINGS["bxclk_delay"], 
+        scan_load_delay=ROUTINE_SETTINGS["scan_load_delay"]
 ):
-    return SettingsScan(loopbackBit, patternIndexes, verbose, vin_test, freq, start_bxclk_state, cfg_test_delay, cfg_test_sample, bxclk_delay, scanload_delay)
+    return SettingsScan(loopbackBit, patternIndexes, verbose, vin_test, freq, start_bxclk_state, cfg_test_delay, cfg_test_sample, bxclk_delay, scan_load_delay)
 
 #<<Registered w/ Spacely as ROUTINE 9, call as ~r9>>
 def ROUTINE_DNNTraining(asic_training=False):

--- a/CMSPIX28Spacely_Subroutines_B0_Prog.py
+++ b/CMSPIX28Spacely_Subroutines_B0_Prog.py
@@ -21,7 +21,10 @@ except ImportError as e:
 # it programs pixel 0 by default
 #-----------------------------------------------------------------------
 
-def ProgShiftRegRaw(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1'):
+# def ProgShiftRegRaw(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1'):
+def ProgShiftRegRaw(
+        configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"]):
 
     #FW reset followed with Status reset
     fw_status_clear()
@@ -109,7 +112,10 @@ def ProgShiftRegRaw(configclk_period='64', cfg_test_delay='5', cfg_test_sample='
 # there is a debug interface that needs to be reworked to check that what is
 #-----------------------------------------------------------------------
 
-def ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1',pixelList = [0], pixelValue=[1]):
+def ProgPixelsOnly(
+        configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"],
+        pixelList = [0], pixelValue=[1]):
     fw_status_clear()
 
     hex_list = [
@@ -160,7 +166,10 @@ def ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='2
 # and a separate list that contains the pixel address and value for each test vectors
 #-----------------------------------------------------------------------
 
-def ProgShiftRegs(progDebug=False, verbose=False, configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1', iP=0, timeSleep=0.015):
+def ProgShiftRegs(progDebug=False, verbose=False, 
+                  configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+                  cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+                  iP=0, timeSleep=0.015):
     fw_status_clear()
 
     hex_list = [

--- a/CMSPIX28Spacely_Subroutines_B1_ScanChain.py
+++ b/CMSPIX28Spacely_Subroutines_B1_ScanChain.py
@@ -10,15 +10,15 @@ except ImportError as e:
     sys.exit(1)  # Exit script immediately
     
 def ScanChainOneShot(
-        scan_load_delay='13', 
-        startBxclkState='0', 
-        bxclk_delay='0B', 
-        bxclk_period='28',
-        injection_delay='1D', 
-        scanLoopBackBit='0', 
-        test_sample='08', 
-        test_delay='03', 
-        scanLoadPhase='20'
+        scan_load_delay= ROUTINE_SETTINGS["scan_load_delay"], #'13', 
+        startBxclkState= ROUTINE_SETTINGS["startBxclkState"], #'0', 
+        bxclk_delay= ROUTINE_SETTINGS["bxclk_delay"], #'0B', 
+        bxclk_period= ROUTINE_SETTINGS["bxclk_period"], #'28',
+        injection_delay= ROUTINE_SETTINGS["injection_delay"], #'1D', 
+        scanLoopBackBit= ROUTINE_SETTINGS["scanLoopBackBit"], #'0', 
+        test_sample= ROUTINE_SETTINGS["test_sample"], #'08', 
+        test_delay= ROUTINE_SETTINGS["test_delay"], #'03', 
+        scanLoadPhase= ROUTINE_SETTINGS["scanLoadPhase"], #'20'
 ):
     x = bin(int(scanLoadPhase, 16))[2:].zfill(6)
     scanLoadPhase1= hex(int(x[:2], 2))[2:]

--- a/CMSPIX28Spacely_Subroutines_B2_SCurve.py
+++ b/CMSPIX28Spacely_Subroutines_B2_SCurve.py
@@ -545,6 +545,7 @@ def SCurveSweepVTH(nPix=0):
     # Sweep range
     biasList = np.arange(0,0.3,0.01)
     # biasList = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8]
+    biasList = [0.05, 0.06, 0.07, 0.08]
     # vthList = [1.5,1.6]
     for i in biasList:
         V_PORT["vth0"].set_voltage(i)
@@ -575,9 +576,9 @@ def SCurveSweepVTH(nPix=0):
             testType = "MatrixVTH"
         )
 
-def SCurveSweepVTHPix():
+def SCurveSweepVTHPix(nPixList=[192]):
     nPix = 256
-    nPixList =  [192]
+    #nPixList =  [192]
     for i in nPixList: #range(nPix):
         SCurveSweepVTH(nPix=i)
 

--- a/CMSPIX28Spacely_Subroutines_B2_SCurve.py
+++ b/CMSPIX28Spacely_Subroutines_B2_SCurve.py
@@ -26,15 +26,15 @@ except ImportError as e:
 #-----------------------------------------------------------------------
     
 def PreProgSCurve(
-        scanLoadPhase = '26',
-        scan_load_delay = '13', 
-        startBxclkState = '0', 
-        bxclk_delay = '12', #'0B', 
-        bxclk_period = '28',
-        injection_delay = '1E', # vin_test_trig_out in the FW
-        scanLoopBackBit = '0', 
-        test_sample = '0F', 
-        test_delay = '14', 
+        scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'26',
+        scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], #'13', 
+        startBxclkState = ROUTINE_SETTINGS["startBxclkState"], #'0', 
+        bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], #'12', #'0B', 
+        bxclk_period = ROUTINE_SETTINGS["bxclk_period"], #'28',
+        injection_delay = ROUTINE_SETTINGS["injection_delay"], #'1E', # vin_test_trig_out in the FW
+        scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"], #'0', 
+        test_sample = ROUTINE_SETTINGS["test_sample"], #'0F', 
+        test_delay = ROUTINE_SETTINGS["test_delay"], #'14', 
         v_min = 0.01, 
         v_max = 0.4, 
         v_step = 0.01, 
@@ -226,15 +226,15 @@ def PreProgSCurve(
 #-----------------------------------------------------------------------
 
 def PreProgSCurveBurst(
-        scan_load_delay = '13', 
-        startBxclkState = '0', 
-        bxclk_delay = '12', #'11', 
-        bxclk_period = '28',
-        injection_delay = '1E', #'17', 
-        scanLoopBackBit = '0', 
-        test_sample = '0F', 
-        scanLoadPhase = '26',
-        test_delay = '14', 
+        scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], #'13', 
+        startBxclkState = ROUTINE_SETTINGS["startBxclkState"], #'0', 
+        bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], #'12', #'11', 
+        bxclk_period = ROUTINE_SETTINGS["bxclk_period"], #'28',
+        injection_delay = ROUTINE_SETTINGS["injection_delay"], #'1E', #'17', 
+        scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"], #'0', 
+        test_sample = ROUTINE_SETTINGS["test_sample"], #'0F', 
+        scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'26',
+        test_delay = ROUTINE_SETTINGS["test_delay"], #'14', 
         tsleep = 100e-3,
         v_min = 0.001, 
         v_max = 0.4, 
@@ -439,18 +439,21 @@ def SCurveMatrix():
     now = datetime.now().strftime("%Y.%m.%d_%H.%M.%S")
 
     for i in range(nPix):
-        ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [i], pixelValue=[1])
+        # ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [i], pixelValue=[1])
+        ProgPixelsOnly(configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+                       cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+                       pixelList = [i], pixelValue=[1])
         
         PreProgSCurveBurst(
-            scan_load_delay = '13', 
-            startBxclkState = '0', 
-            bxclk_delay = '11',         #superpix1 '11', superpix2 '12',
-            bxclk_period = '28', 
-            injection_delay = '1C',     #superpix1 '1C', superpix2 '1E',
-            scanLoopBackBit = '0', 
-            test_sample = '0F', 
-            scanLoadPhase ='25',        #superpix1 '25', superpix2 '26',
-            test_delay = '14', 
+            scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], # '13', 
+            startBxclkState = ROUTINE_SETTINGS["startBxclkState"], # '0', 
+            bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], # '11',         #superpix1 '11', superpix2 '12',
+            bxclk_period = ROUTINE_SETTINGS["bxclk_period"], # '28', 
+            injection_delay = ROUTINE_SETTINGS["injection_delay"], # '1C',     #superpix1 '1C', superpix2 '1E',
+            scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"], # '0', 
+            test_sample = ROUTINE_SETTINGS["test_sample"], # '0F', 
+            scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'25',        #superpix1 '25', superpix2 '26',
+            test_delay = ROUTINE_SETTINGS["test_delay"], # '14', 
             v_min = 0.001, 
             v_max = 0.4, 
             v_step = 0.001, 
@@ -479,7 +482,11 @@ def SCurveSweepIbias(nPix=0):
 
     print(nPix)
     #program single pixel
-    ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [nPix], pixelValue=[1])
+    # ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk='1', pixelList = [nPix], pixelValue=[1])
+    ProgPixelsOnly(
+        configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+        cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+        pixelList = [nPix], pixelValue=[1])
     
 
     # create an output directory/mnt/local/CMSPIX28/Scurve/data/ChipVersion1_ChipID9_SuperPix2/2025.02.25_08.36.02_Matrix_vMin0.001_vMax0.600_vStep0.00100_nSample1000.000_vdda0.900_VTH0.800_BXCLK10.00/nPix0.8
@@ -495,15 +502,15 @@ def SCurveSweepIbias(nPix=0):
         V_LEVEL["Ibias"] = i
         V_PORT["vdda"].get_current()
         PreProgSCurveBurst(
-            scan_load_delay = '13', 
-            startBxclkState = '0', 
-            bxclk_delay = '12', #'0B', 
-            bxclk_period = '28', 
-            injection_delay = '1E', #'1D', 
-            scanLoopBackBit = '0', 
-            test_sample = '0F', 
-            scanLoadPhase ='26',
-            test_delay = '14', 
+            scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"] , # '13', 
+            startBxclkState = ROUTINE_SETTINGS["startBxclkState"] , # '0', 
+            bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"] , # '12', #'0B', 
+            bxclk_period = ROUTINE_SETTINGS["bxclk_period"] , # '28', 
+            injection_delay = ROUTINE_SETTINGS["injection_delay"] , # '1E', #'1D', 
+            scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"] , # '0', 
+            test_sample = ROUTINE_SETTINGS["test_sample"] , # '0F', 
+            scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"] , #'26',
+            test_delay = ROUTINE_SETTINGS["test_delay"] , # '14', 
             v_min = 0.001, 
             v_max = 0.4, 
             v_step = 0.001, 
@@ -525,7 +532,10 @@ def SCurveSweepVTH(nPix=0):
 
     print(nPix)
     #program single pixel
-    ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [nPix], pixelValue=[1])
+    # ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [nPix], pixelValue=[1])
+    ProgPixelsOnly(configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+                   cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+                   pixelList = [nPix], pixelValue=[1])
     
 
     # create an output directory/mnt/local/CMSPIX28/Scurve/data/ChipVersion1_ChipID9_SuperPix2/2025.02.25_08.36.02_Matrix_vMin0.001_vMax0.600_vStep0.00100_nSample1000.000_vdda0.900_VTH0.800_BXCLK10.00/nPix0.8
@@ -545,15 +555,15 @@ def SCurveSweepVTH(nPix=0):
         V_LEVEL["vth2"] = i
         V_PORT["vdda"].get_current()
         PreProgSCurveBurst(
-            scan_load_delay = '13', 
-            startBxclkState = '0', 
-            bxclk_delay = '12', #'0B', 
-            bxclk_period = '28', 
-            injection_delay = '1E', #'1D', 
-            scanLoopBackBit = '0', 
-            test_sample = '0F', 
-            scanLoadPhase ='26',
-            test_delay = '14', 
+            scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], # '13', 
+            startBxclkState = ROUTINE_SETTINGS["startBxclkState"], # '0', 
+            bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], # '12', #'0B', 
+            bxclk_period = ROUTINE_SETTINGS["bxclk_period"], # '28', 
+            injection_delay = ROUTINE_SETTINGS["injection_delay"], # '1E', #'1D', 
+            scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"], # '0', 
+            test_sample = ROUTINE_SETTINGS["test_sample"], # '0F', 
+            scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'26',
+            test_delay = ROUTINE_SETTINGS["test_delay"], # '14', 
             v_min = 0.001, 
             v_max = 0.4, 
             v_step = 0.001, 
@@ -581,7 +591,10 @@ def SCurveSweep(nPix=0,  FWparameter = None, minPar = 0, maxPar = 28, stepPar = 
 # parameter is expected to match FW name and be a string
 
     #program single pixel
-    ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [nPix], pixelValue=[1])
+    # ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [nPix], pixelValue=[1])
+    ProgPixelsOnly(configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+                   cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+                   pixelList = [nPix], pixelValue=[1])
 
     # create an output directory/mnt/local/CMSPIX28/Scurve/data/ChipVersion1_ChipID9_SuperPix2/2025.02.25_08.36.02_Matrix_vMin0.001_vMax0.600_vStep0.00100_nSample1000.000_vdda0.900_VTH0.800_BXCLK10.00/nPix0.8
     dataDir = FNAL_SETTINGS["storageDirectory"]
@@ -595,15 +608,15 @@ def SCurveSweep(nPix=0,  FWparameter = None, minPar = 0, maxPar = 28, stepPar = 
 
             V_PORT["vdda"].get_current()
             PreProgSCurveBurst(
-                scan_load_delay = '13', 
-                startBxclkState = '0', 
-                bxclk_delay = '12', #'12', 
-                bxclk_period = '28', 
-                injection_delay = i, 
-                scanLoopBackBit = '0', 
-                test_sample = '0F', 
-                scanLoadPhase ='26',
-                test_delay = '14', 
+                scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], # '13', 
+                startBxclkState = ROUTINE_SETTINGS["startBxclkState"], # '0', 
+                bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], # '12', #'12', 
+                bxclk_period = ROUTINE_SETTINGS["bxclk_period"], # '28', 
+                injection_delay= i, 
+                scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"], # '0', 
+                test_sample = ROUTINE_SETTINGS["test_sample"], # '0F', 
+                scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'26',
+                test_delay = ROUTINE_SETTINGS["test_delay"], # '14', 
                 v_min = 0.001, 
                 v_max = 0.4, 
                 v_step = 0.001, 
@@ -626,15 +639,15 @@ def SCurveSweep(nPix=0,  FWparameter = None, minPar = 0, maxPar = 28, stepPar = 
             time.sleep(0.1) # added time for pulse generator to settle
             V_PORT["vdda"].get_current()
             PreProgSCurveBurst(
-                scan_load_delay = '13', 
-                startBxclkState = '0', 
-                bxclk_delay = '12', #'0B', 
-                bxclk_period = '28', 
-                injection_delay = '1E', 
-                scanLoopBackBit = '0', 
-                test_sample = '0F', 
-                scanLoadPhase ='26',
-                test_delay = '14', 
+                scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], # '13', 
+                startBxclkState = ROUTINE_SETTINGS["startBxclkState"], # '0', 
+                bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], # '12', #'0B', 
+                bxclk_period = ROUTINE_SETTINGS["bxclk_period"], # '28', 
+                injection_delay = ROUTINE_SETTINGS["injection_delay"], # '1E', 
+                scanLoopBackBit = ROUTINE_SETTINGS["scanLoopBackBit"], # '0', 
+                test_sample = ROUTINE_SETTINGS["test_sample"], # '0F', 
+                scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'26',
+                test_delay = ROUTINE_SETTINGS["test_delay"], # '14', 
                 v_min = 0.001, 
                 v_max = 0.4, 
                 v_step = 0.001, 

--- a/CMSPIX28Spacely_Subroutines_B3_DNN.py
+++ b/CMSPIX28Spacely_Subroutines_B3_DNN.py
@@ -623,3 +623,14 @@ def DNN_analyse(debug=False, latency_bit=37, bxclkFreq='28', readout_CSV="readou
 
     # interpret data from chip to just give NN prediction
     # return reshaped_dnn_out
+
+
+
+#quick function to set discriminator voltages
+def setDisc(volt0, volt1):
+    V_PORT["disc0"].set_voltage(volt0)
+    V_LEVEL["disc0"] = volt0
+    #measure bias 7
+    V_PORT["disc1"].set_voltage(volt1)
+    V_LEVEL["disc1"] = volt1
+    #measure bias 9

--- a/CMSPIX28Spacely_Subroutines_B3_DNN.py
+++ b/CMSPIX28Spacely_Subroutines_B3_DNN.py
@@ -13,24 +13,25 @@ except ImportError as e:
 
 def DNN(
     progDebug=False,
-    loopbackBit=0, 
+    loopbackBit=ROUTINE_SETTINGS["loopbackBit"], 
     patternIndexes = [0], 
     verbose=False, 
-    injection_delay='1E', 
-    bxclk_period='28', 
-    startBxclkState='0',
-    scan_load_delay='13', 
-    cfg_test_delay='5', 
-    cfg_test_sample='20', 
-    progResetMask='0', 
-    configclk_period='64', 
-    test_delay='14', 
-    test_sample='0F', 
-    bxclk_delay='12',
-    configClkGate='0',
-    scanLoadPhase ='26', 
+    injection_delay= ROUTINE_SETTINGS["injection_delay"], #'1E', 
+    bxclk_period= ROUTINE_SETTINGS["bxclk_period"], #'28', 
+    startBxclkState= ROUTINE_SETTINGS["startBxclkState"], #'0',
+    scan_load_delay= ROUTINE_SETTINGS["scan_load_delay"], #'13', 
+    cfg_test_delay= ROUTINE_SETTINGS["cfg_test_delay"], #'5', 
+    cfg_test_sample= ROUTINE_SETTINGS["cfg_test_sample"], #'20', 
+    progResetMask= ROUTINE_SETTINGS["progResetMask"], #'0', 
+    configclk_period= ROUTINE_SETTINGS["configclk_period"], #'64', 
+    test_delay= ROUTINE_SETTINGS["test_delay"], #'14', 
+    test_sample= ROUTINE_SETTINGS["test_sample"], #'0F', 
+    bxclk_delay= ROUTINE_SETTINGS["bxclk_delay"], #'12',
+    configClkGate= ROUTINE_SETTINGS["configClkGate"], #'0',
+    scanLoadPhase= ROUTINE_SETTINGS["scanLoadPhase"], #'26', 
     dnn_csv=None, 
     pixel_compout_csv=None, 
+    hidden_csv=None,
     dataDir = FNAL_SETTINGS["storageDirectory"],
     dateTime = None,
     vth0=0.08,
@@ -86,7 +87,8 @@ def DNN(
 
 
     # load all of the configs
-    filename = pixel_compout_csv if pixel_compout_csv else "/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_D/tb/dnn/csv/l6/compouts.csv"
+    # filename = pixel_compout_csv if pixel_compout_csv else "/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_D/tb/dnn/csv/l6/compouts.csv"
+    filename = pixel_compout_csv if pixel_compout_csv else "./spacely-asic-config/CMSPIX28Spacely/csv/compouts.csv"
     pixelLists, pixelValues = genPixelConfigFromInputCSV(filename)
 
     # loop over test cases
@@ -102,7 +104,8 @@ def DNN(
         
         # increment counter of number of patterns
         iN += 1
-        hiddenBit=hidden_csv if hidden_csv else "/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/hidden_debug.csv"
+        #hiddenBit=hidden_csv if hidden_csv else "/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/hidden_debug.csv"
+        hiddenBit=hidden_csv if hidden_csv else "./spacely-asic-config/CMSPIX28Spacely/csv/hidden_debug.csv"
 
         # pick up pixel config for the given pattern
         pixelConfig = genPixelProgramList(pixelLists[iP], pixelValues[iP])
@@ -110,10 +113,11 @@ def DNN(
         # Programming the NN weights and biases
         # THIS TAKES SIGNIFICANT AMOUNT OF TIME (~0.3sec) --> COULD IMPROVE --<
         if(progDebug==True):
-            hex_lists = dnnConfig('/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/b5_w5_b2_w2_pixel_bin_debug2.csv', pixelConfig = pixelConfig, hiddenBitCSV = hiddenBit)
+            #hex_lists = dnnConfig('/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/b5_w5_b2_w2_pixel_bin_debug2.csv', pixelConfig = pixelConfig, hiddenBitCSV = hiddenBit)
+            hex_lists = dnnConfig('./spacely-asic-config/CMSPIX28Spacely/csv/b5_w5_b2_w2_pixel_bin_debug2.csv', pixelConfig = pixelConfig, hiddenBitCSV = hiddenBit)
         else:
-            filename = dnn_csv if dnn_csv else '/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/b5_w5_b2_w2_pixel_bin.csv'
-            
+            #filename = dnn_csv if dnn_csv else '/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/b5_w5_b2_w2_pixel_bin.csv'
+            filename = dnn_csv if dnn_csv else './spacely-asic-config/CMSPIX28Spacely/csv/b5_w5_b2_w2_pixel_bin.csv'
             # hex_lists = dnnConfig('/asic/projects/C/CMS_PIX_28/benjamin/verilog/workarea/cms28_smartpix_verification/PnR_cms28_smartpix_verification_A/tb/dnn/csv/l6/b5_w5_b2_w2_pixel_bin.csv', pixelConfig = pixelConfig, hiddenBitCSV = hiddenBit)
             hex_lists = dnnConfig(filename, pixelConfig = pixelConfig, hiddenBitCSV = hiddenBit)
         sw_write32_0(hex_lists)
@@ -402,22 +406,22 @@ def DNN_power(n_tb=100, waitTime=1.4, dnnwaitTime=1, pNoiseBool=False, vth0=0.01
         #set pulse generator in normal condition
         DNN(
         progDebug=False,
-        loopbackBit=0, 
+        loopbackBit=ROUTINE_SETTINGS["loopbackBit"], 
         patternIndexes = [0], 
         verbose=False, 
-        injection_delay='1E', 
-        bxclk_period='28', 
-        startBxclkState='0',
-        scan_load_delay='13', 
-        cfg_test_delay='5', 
-        cfg_test_sample='20', 
-        progResetMask='0', 
-        configclk_period='64', 
-        test_delay='14', 
-        test_sample='0F', 
-        bxclk_delay='12',
-        configClkGate='0',
-        scanLoadPhase ='26', 
+        injection_delay=  ROUTINE_SETTINGS["injection_delay"], #'1E', 
+        bxclk_period=  ROUTINE_SETTINGS["bxclk_period"], #'28', 
+        startBxclkState=  ROUTINE_SETTINGS["startBxclkState"], #'0',
+        scan_load_delay=  ROUTINE_SETTINGS["scan_load_delay"], #'13', 
+        cfg_test_delay=  ROUTINE_SETTINGS["cfg_test_delay"], #'5', 
+        cfg_test_sample=  ROUTINE_SETTINGS["cfg_test_sample"], #'20', 
+        progResetMask=  ROUTINE_SETTINGS["progResetMask"], #'0', 
+        configclk_period=  ROUTINE_SETTINGS["configclk_period"], #'64', 
+        test_delay=  ROUTINE_SETTINGS["test_delay"], #'14', 
+        test_sample=  ROUTINE_SETTINGS["test_sample"], #'0F', 
+        bxclk_delay=  ROUTINE_SETTINGS["bxclk_delay"], #'12',
+        configClkGate=  ROUTINE_SETTINGS["configClkGate"], #'0',
+        scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'26', 
         dnn_csv=None, 
         pixel_compout_csv=None, 
         dataDir = FNAL_SETTINGS["storageDirectory"],
@@ -454,22 +458,22 @@ def DNN_power(n_tb=100, waitTime=1.4, dnnwaitTime=1, pNoiseBool=False, vth0=0.01
             #set pulse generator in normal condition
             DNN(
             progDebug=False,
-            loopbackBit=0, 
+            loopbackBit=ROUTINE_SETTINGS["loopbackBit"],#0, 
             patternIndexes = [i], 
             verbose=False, 
-            injection_delay='1E', 
-            bxclk_period='28', 
-            startBxclkState='0',
-            scan_load_delay='13', 
-            cfg_test_delay='5', 
-            cfg_test_sample='20', 
-            progResetMask='0', 
-            configclk_period='64', 
-            test_delay='14', 
-            test_sample='0F', 
-            bxclk_delay='12',
-            configClkGate='0',
-            scanLoadPhase ='26', 
+            injection_delay= ROUTINE_SETTINGS["injection_delay"], #'1E', 
+            bxclk_period= ROUTINE_SETTINGS["bxclk_period"], #'28', 
+            startBxclkState= ROUTINE_SETTINGS["startBxclkState"], #'0',
+            scan_load_delay= ROUTINE_SETTINGS["scan_load_delay"], #'13', 
+            cfg_test_delay= ROUTINE_SETTINGS["cfg_test_delay"], #'5', 
+            cfg_test_sample= ROUTINE_SETTINGS["cfg_test_sample"], #'20', 
+            progResetMask= ROUTINE_SETTINGS["progResetMask"], #'0', 
+            configclk_period= ROUTINE_SETTINGS["configclk_period"], #'64', 
+            test_delay= ROUTINE_SETTINGS["test_delay"], #'14', 
+            test_sample= ROUTINE_SETTINGS["test_sample"], #'0F', 
+            bxclk_delay= ROUTINE_SETTINGS["bxclk_delay"], #'12',
+            configClkGate= ROUTINE_SETTINGS["configClkGate"], #'0',
+            scanLoadPhase= ROUTINE_SETTINGS["scanLoadPhase"], #'26', 
             dnn_csv=None, 
             pixel_compout_csv=None, 
             dataDir = FNAL_SETTINGS["storageDirectory"],

--- a/CMSPIX28Spacely_Subroutines_B4_SettingsScan.py
+++ b/CMSPIX28Spacely_Subroutines_B4_SettingsScan.py
@@ -28,14 +28,14 @@ except ImportError as e:
 # **********************************************************************************
     
 def settingsScanSampleFW(
-        bxclk_period='28', 
-        start_bxclk_state='0', 
-        cfg_test_sample='08', 
-        bxclk_delay= '0B', #'11', 
-        injection_delay='1D', #'04', 
-        loopbackBit='0', 
-        cfg_test_delay='03', 
-        scan_load_delay='13', 
+        bxclk_period= ROUTINE_SETTINGS["bxclk_period"], #'28', 
+        start_bxclk_state= ROUTINE_SETTINGS["startBxclkState"], #'0', 
+        cfg_test_sample= ROUTINE_SETTINGS["cfg_test_sample"], #'08', #default is '20', original was '08'
+        bxclk_delay= ROUTINE_SETTINGS["bxclk_delay"], # '0B', #'11', #default is '12', original was '0B'
+        injection_delay= ROUTINE_SETTINGS["injection_delay"], #'1D', #'04',  #default is '1E', original was '1D'
+        loopbackBit= ROUTINE_SETTINGS["loopbackBit"], #'0', 
+        cfg_test_delay= ROUTINE_SETTINGS["cfg_test_delay"], #'03', #default is '5', original was '03'
+        scan_load_delay= ROUTINE_SETTINGS["scan_load_delay"], #'13', 
         scanIndata='0001', 
         nrepeat=1, 
         debug=False,
@@ -280,18 +280,18 @@ def settingsScanSampleFW(
 # If BxCLK frequency shifts, the Sample Delay will need to be retuned 
 # **********************************************************************************
 def calibrationMatrixHighStat(
-        scanLoadPhase = '27', # DEAULT VALUE '25',
+        scanLoadPhase = ROUTINE_SETTINGS["scanLoadPhase"], #'27', # DEAULT VALUE '25', #default is actually '26', original was '27'
         tsleep = 200e-6,
         tsleep2 = 0.5,
         loopbackBit=0, 
-        bxclk_period='28', 
+        bxclk_period=ROUTINE_SETTINGS["bxclk_period"], #'28', 
         nsample=32,
         v_min = 0.001, 
         v_max = 0.4, 
         v_step = 0.034, 
-        bxclk_delay = '13', # DEFAULT VALUE '11',
-        injection_delay = '1F', # DEFAULT VALUE '1D',
-        scan_load_delay = '13',
+        bxclk_delay = ROUTINE_SETTINGS["bxclk_delay"], #'13', # DEFAULT VALUE '11', #default is actually '12', original was '13'
+        injection_delay = ROUTINE_SETTINGS["injection_delay"], #'1F', # DEFAULT VALUE '1D', #default is actually '1E', original was '1F'
+        scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], #'13',
         dateTime = None,
         dataDir = FNAL_SETTINGS["storageDirectory"],
         testType = "MatrixCalibration",
@@ -394,7 +394,9 @@ def calibrationMatrixHighStat(
         for iN, nPix in enumerate(pixList):
                     
             # program shift register
-            ProgPixelsOnly(configclk_period='64', cfg_test_delay='5', cfg_test_sample='20',cfg_test_gate_config_clk ='1', pixelList = [nPix], pixelValue=[1])
+            ProgPixelsOnly(configclk_period=ROUTINE_SETTINGS["configclk_period"], cfg_test_delay=ROUTINE_SETTINGS["cfg_test_delay"], 
+                           cfg_test_sample=ROUTINE_SETTINGS["cfg_test_sample"],cfg_test_gate_config_clk=ROUTINE_SETTINGS["cfg_test_gate_config_clk"], 
+                           pixelList = [nPix], pixelValue=[1])
 
             # pix value in hex
             nPixHex = int_to_32bit_hex(nPix)
@@ -536,14 +538,14 @@ def calibrationMatrixHighStatExtraction():
                 tsleep = 200e-6,
                 tsleep2 = 0.5,
                 loopbackBit=0, 
-                bxclk_period='28', 
+                bxclk_period= ROUTINE_SETTINGS["bxclk_period"], #'28', 
                 nsample=32,
                 v_min = 0.001, 
                 v_max = 0.4, 
                 v_step = 0.034, 
                 bxclk_delay = bxclk_delay,
                 injection_delay = injection_delay,
-                scan_load_delay = '13',
+                scan_load_delay = ROUTINE_SETTINGS["scan_load_delay"], #'13',
                 dateTime = None,
                 dataDir = FNAL_SETTINGS["storageDirectory"],
                 testType = "MatrixCalibration",

--- a/CMSPIX28Spacely_Subroutines_B5_DNNTraining.py
+++ b/CMSPIX28Spacely_Subroutines_B5_DNNTraining.py
@@ -279,9 +279,16 @@ class ModelPipeline:
         freq = '3F'
         DNN(
             progDebug=False, loopbackBit=0, patternIndexes = None, verbose=False, # update range when finished
-            vinTest='20', freq=freq, startBxclkState='0',scanloadDly='B', 
-            progDly='40', progSample='4', progResetMask='0', progFreq='64', 
-            testDelaySC='08', sampleDelaySC='08', bxclkDelay='14', configClkGate='1',  
+            vinTest='20', freq=freq, 
+            startBxclkState= ROUTINE_SETTINGS["startBxclkState"],scan_load_delay= ROUTINE_SETTINGS["scan_load_delay"],
+            # startBxclkState='0',scanloadDly='B',  #original setting, which is not quite the default
+            progDly='40', progSample='4', #I don't think the function actually takes in these parameters ???
+            # progDly='40', progSample='4',  #original setting, which is not quite the default
+            progResetMask= ROUTINE_SETTINGS["progResetMask"], progFreq='64', #I don't think the function takes in progFreq
+            # progResetMask='0', progFreq='64',  #original setting, which is not quite the default
+            testDelaySC='08', sampleDelaySC='08',
+            bxclkDelay= ROUTINE_SETTINGS["bxclkDelay"], configClkGate= ROUTINE_SETTINGS["configClkGate"], 
+            # bxclkDelay='14', configClkGate='1',   #original setting, which is not quite the default
             dnn_csv = dnn_csv,
             pixel_compout_csv = pixel_compout_csv,
             outDir = "./tmp",


### PR DESCRIPTION
Added a dictionary in CMSPIX28Spacely_Config.py called ROUTINE_SETTINGS
	which holds default values for several delays, period, and
	other standard variables used in all the routines.
	Used the most common default values appearing in
	CMSPIX28Spacely_Routines.py
Edited CMSPIX28Spacely_Routines.py and ..._Subroutines_B* to use the
	default values from the ROUTINE_SETTINGS in the config file.
Note: In some files, replaced nondefault values with the defaults in
	ROUTINE_SETTINGS. Made a comment whenever this was the case.
	In particular, in routine 8 the settings scan in Routines.py
	ln 142;
	in the Subroutines_B4_SettingsScan.py in functions
	calibrationMatrixHighStat, ln 283, 292 and
	settingsScanSampleFW, ln 33, 34, 37;
	in the Subroutine_B5.
Note: Noticed several possible bugs in Subroutine_B5_ where parameters
	were passed into the DNN function which I don't think exist
	in the actual DNN function in Subroutines_B3_DNN.py
Note: The FNAL_SETTINGS and INSTR configurations should be edited
	for fermilab/cornell with local IP addresses, chip settings.